### PR TITLE
Add initial cash config and 30% selection

### DIFF
--- a/Parameters.yaml
+++ b/Parameters.yaml
@@ -25,8 +25,8 @@ IndicatorWeights:
   RSI: 1.0
   Volatility: 1.0
 MomentumWeight: 1.0
-TopN: 2
 AllocationMethod: equal
 CsvPath: portfolio.csv
 JsonPath: portfolio.json
 RebalanceIntervalMonths: 3
+InitialCash: 10000

--- a/UnitTests/test_backtesting_engine.py
+++ b/UnitTests/test_backtesting_engine.py
@@ -9,6 +9,7 @@ class TestBacktestingEngine(unittest.TestCase):
     def setUp(self) -> None:
         self.fetcher = MarketDataFetcher()
         self.engine = BacktestingEngine(self.fetcher)
+        self.engine_config = BacktestingEngine(self.fetcher, {"InitialCash": 5000})
         dates_train = pd.date_range("2020-01-01", periods=4, freq="D")
         dates_test = pd.date_range("2024-01-01", periods=90, freq="D")
         all_dates = dates_train.append(dates_test)
@@ -43,6 +44,9 @@ class TestBacktestingEngine(unittest.TestCase):
         mock_adapter.side_effect = self.fake_adapter
         result = self.engine.IntervalBacktest(["AAA", "BBB", "CCC"], 1)
         self.assertGreater(result, 0)
+
+    def test_initial_cash_from_config(self):
+        self.assertEqual(self.engine_config.initial_cash, 5000)
 
     @patch.object(MarketDataFetcher, "MarketDataAdapter")
     def test_portfolio_backtest_rebalance(self, mock_adapter):

--- a/main.py
+++ b/main.py
@@ -58,7 +58,8 @@ def main() -> None:
         )
         scaled = scorer.ScoreScaler(combined)
 
-        top = portfolio.PortfolioSelector(scaled, config.get("TopN", 1))
+        TopCount = max(int(len(tickers) * 0.3), 1)
+        top = portfolio.PortfolioSelector(scaled, TopCount)
         alloc = portfolio.AllocationCalculator(
             top, method=config.get("AllocationMethod", "equal")
         )
@@ -69,7 +70,7 @@ def main() -> None:
             config.get("JsonPath", "portfolio.json"),
         )
 
-        backtester = BacktestingEngine(fetcher)
+        backtester = BacktestingEngine(fetcher, config)
         hist_alloc = backtester.AllocationFromHistory(tickers)
         interval = config.get("RebalanceIntervalMonths", 0)
         backtest_return = backtester.PortfolioBacktest(hist_alloc, interval)


### PR DESCRIPTION
## Summary
- make backtesting initial cash configurable via `Parameters.yaml`
- pick top 30% of tickers in `main.py`
- pass config to `BacktestingEngine`
- test initial cash configuration