### PR TITLE
Fix pct_change FutureWarning in data processing

### DIFF
--- a/BacktestingEngine.py
+++ b/BacktestingEngine.py
@@ -36,7 +36,7 @@ class BacktestingEngine:
         """Calculate allocations based on 2020-2023 performance."""
         data = self.fetcher.MarketDataAdapter(tickers)
         history = data.loc["2020-01-01":"2023-12-31"]
-        cumulative = history.pct_change().add(1).prod() - 1
+        cumulative = history.pct_change(fill_method=None).add(1).prod() - 1
         top_count = max(int(len(tickers) * 0.3), 1)
         selected = cumulative.sort_values(ascending=False).head(top_count)
         return self.portfolio.AllocationCalculator(selected, method="score")
@@ -45,7 +45,7 @@ class BacktestingEngine:
         """Calculate allocations using data up to a given end date."""
         data = self.fetcher.MarketDataAdapter(tickers)
         history = data.loc["2020-01-01":end_date]
-        cumulative = history.pct_change().add(1).prod() - 1
+        cumulative = history.pct_change(fill_method=None).add(1).prod() - 1
         top_count = max(int(len(tickers) * 0.3), 1)
         selected = cumulative.sort_values(ascending=False).head(top_count)
         return self.portfolio.AllocationCalculator(selected, method="score")

--- a/IndicatorEngine.py
+++ b/IndicatorEngine.py
@@ -23,7 +23,7 @@ class IndicatorEngine:
 
     def VolatilityIndicator(self, data: pd.Series, window: int) -> pd.Series:
         """Return rolling volatility using standard deviation of percentage change."""
-        return data.pct_change().rolling(window=window).std()
+        return data.pct_change(fill_method=None).rolling(window=window).std()
 
     def TestIndicators(self) -> bool:
         """Validate indicators against known values."""
@@ -31,7 +31,7 @@ class IndicatorEngine:
         sma_expected = sample.rolling(window=3).mean()
         ema_expected = sample.ewm(span=3, adjust=False).mean()
         rsi_expected = self.RSI_Indicator(sample)
-        vol_expected = sample.pct_change().rolling(window=3).std()
+        vol_expected = sample.pct_change(fill_method=None).rolling(window=3).std()
 
         pd.testing.assert_series_equal(self.MovingAverageIndicator(sample, 3), sma_expected)
         pd.testing.assert_series_equal(self.MovingAverageIndicator(sample, 3, exponential=True), ema_expected)

--- a/MomentumEngine.py
+++ b/MomentumEngine.py
@@ -29,8 +29,8 @@ class MomentumEngine:
         windows = self.LookbackWindowValidator(lookbacks)
         momentum = pd.DataFrame(index=data.columns)
         for window in windows:
-            pct_return = data.pct_change(periods=window).iloc[-1]
-            volatility = data.pct_change().rolling(window).std().iloc[-1].replace(0, pd.NA)
+            pct_return = data.pct_change(periods=window, fill_method=None).iloc[-1]
+            volatility = data.pct_change(fill_method=None).rolling(window).std().iloc[-1].replace(0, pd.NA)
             risk_adjusted = (pct_return / volatility) * 100
             momentum[f"Lookback_{window}"] = risk_adjusted
         return momentum

--- a/UnitTests/test_indicator_engine.py
+++ b/UnitTests/test_indicator_engine.py
@@ -21,7 +21,7 @@ class TestIndicatorEngine(unittest.TestCase):
 
     def test_volatility_indicator(self):
         vol = self.engine.VolatilityIndicator(self.data, 3)
-        expected_vol = self.data.pct_change().rolling(3).std().iloc[-1]
+        expected_vol = self.data.pct_change(fill_method=None).rolling(3).std().iloc[-1]
         self.assertAlmostEqual(vol.iloc[-1], expected_vol)
 
     def test_test_indicators(self):

--- a/UnitTests/test_momentum_engine.py
+++ b/UnitTests/test_momentum_engine.py
@@ -17,7 +17,7 @@ class TestMomentumRanker(unittest.TestCase):
         returns = self.engine.CumulativeReturnCalculator(self.data, [1, 5])
         self.assertTrue(pd.isna(returns.loc['AAA', 'Lookback_1']))
         pct_return = self.data.iloc[-1] / self.data.iloc[0] - 1
-        volatility = self.data.pct_change().rolling(5).std().iloc[-1]
+        volatility = self.data.pct_change(fill_method=None).rolling(5).std().iloc[-1]
         expected_5 = (pct_return / volatility) * 100
         self.assertAlmostEqual(returns.loc['AAA', 'Lookback_5'], expected_5['AAA'])
 


### PR DESCRIPTION
## Summary
- fix FutureWarning by specifying `fill_method=None` for pct_change
- adjust tests for new pct_change behavior