### PR TITLE
Add volatility-adjusted allocation method

### DIFF
--- a/Parameters.yaml
+++ b/Parameters.yaml
@@ -47,7 +47,7 @@ IndicatorWeights:
   RSI: 1.0
   Volatility: 1.0
 MomentumWeight: 1.0
-AllocationMethod: equal
+AllocationMethod: volatility
 CsvPath: portfolio.csv
 JsonPath: portfolio.json
 RebalanceIntervalMonths: 3

--- a/UnitTests/test_portfolio_engine.py
+++ b/UnitTests/test_portfolio_engine.py
@@ -26,6 +26,18 @@ class TestPortfolioEngine(unittest.TestCase):
         expected = selected / selected.sum()
         pd.testing.assert_series_equal(alloc, expected)
 
+    def test_volatility_adjusted_allocation(self):
+        VolSeries = pd.Series({"AAA": 0.2, "BBB": 0.1, "CCC": 0.4})
+        alloc = self.engine.VolatilityAdjustedAllocation(VolSeries)
+        Expected = (1 / VolSeries) / (1 / VolSeries).sum()
+        pd.testing.assert_series_equal(alloc, Expected)
+
+    def test_allocation_calculator_volatility(self):
+        VolSeries = pd.Series({"AAA": 0.2, "BBB": 0.1})
+        alloc = self.engine.AllocationCalculator(VolSeries, method="volatility")
+        Expected = (1 / VolSeries) / (1 / VolSeries).sum()
+        pd.testing.assert_series_equal(alloc, Expected)
+
     def test_portfolio_exporter(self):
         selected = self.engine.PortfolioSelector(self.scores, 2)
         alloc = self.engine.AllocationCalculator(selected)

--- a/main.py
+++ b/main.py
@@ -60,9 +60,14 @@ def main() -> None:
 
         TopCount = max(int(len(tickers) * 0.3), 1)
         top = portfolio.PortfolioSelector(scaled, TopCount)
-        alloc = portfolio.AllocationCalculator(
-            top, method=config.get("AllocationMethod", "equal")
-        )
+        allocation_method = config.get("AllocationMethod", "equal")
+        if allocation_method == "volatility":
+            VolatilitySeries = df_clean.loc[top.index, "Volatility"]
+            alloc = portfolio.AllocationCalculator(
+                VolatilitySeries, method="volatility"
+            )
+        else:
+            alloc = portfolio.AllocationCalculator(top, method=allocation_method)
         portfolio.PortfolioExporter(
             top,
             alloc,


### PR DESCRIPTION
## Summary
- implement `VolatilityAdjustedAllocation` in `PortfolioEngine`
- support the new option in `AllocationCalculator`
- update `Parameters.yaml` to use volatility allocation
- enable volatility-based portfolio generation in `main.py`
- add unit tests for the new method