### PR TITLE
Add MACD, Bollinger Bands, and ADI indicators

### DIFF
--- a/IndicatorEngine.py
+++ b/IndicatorEngine.py
@@ -25,6 +25,39 @@ class IndicatorEngine:
         """Return rolling volatility using standard deviation of percentage change."""
         return data.pct_change(fill_method=None).rolling(window=window).std()
 
+    def MACDIndicator(
+        self,
+        data: pd.Series,
+        short_window: int = 12,
+        long_window: int = 26,
+        signal_window: int = 9,
+    ) -> pd.Series:
+        """Compute the MACD histogram."""
+        ema_short = data.ewm(span=short_window, adjust=False).mean()
+        ema_long = data.ewm(span=long_window, adjust=False).mean()
+        macd = ema_short - ema_long
+        signal = macd.ewm(span=signal_window, adjust=False).mean()
+        histogram = macd - signal
+        return histogram
+
+    def BollingerBandsIndicator(
+        self, data: pd.Series, window: int = 20, num_std: int = 2
+    ) -> pd.Series:
+        """Return Bollinger Bands percent-b indicator."""
+        sma = data.rolling(window=window).mean()
+        std = data.rolling(window=window).std()
+        upper = sma + num_std * std
+        lower = sma - num_std * std
+        percent_b = (data - lower) / (upper - lower)
+        return percent_b
+
+    def ADIIndicator(self, data: pd.Series, window: int = 14) -> pd.Series:
+        """Compute a simple Advance-Decline Indicator."""
+        up = (data.diff() > 0).astype(int)
+        down = (data.diff() < 0).astype(int)
+        adv_dec = up.rolling(window).sum() - down.rolling(window).sum()
+        return adv_dec
+
     def TestIndicators(self) -> bool:
         """Validate indicators against known values."""
         sample = pd.Series(range(1, 11), dtype=float)
@@ -33,8 +66,24 @@ class IndicatorEngine:
         rsi_expected = self.RSI_Indicator(sample)
         vol_expected = sample.pct_change(fill_method=None).rolling(window=3).std()
 
+        macd_line = sample.ewm(span=12, adjust=False).mean() - sample.ewm(span=26, adjust=False).mean()
+        macd_expected = macd_line - macd_line.ewm(span=9, adjust=False).mean()
+
+        sma_bb = sample.rolling(window=3).mean()
+        std_bb = sample.rolling(window=3).std()
+        upper_bb = sma_bb + 2 * std_bb
+        lower_bb = sma_bb - 2 * std_bb
+        bb_expected = (sample - lower_bb) / (upper_bb - lower_bb)
+
+        up = (sample.diff() > 0).astype(int)
+        down = (sample.diff() < 0).astype(int)
+        adi_expected = up.rolling(3).sum() - down.rolling(3).sum()
+
         pd.testing.assert_series_equal(self.MovingAverageIndicator(sample, 3), sma_expected)
         pd.testing.assert_series_equal(self.MovingAverageIndicator(sample, 3, exponential=True), ema_expected)
         pd.testing.assert_series_equal(self.RSI_Indicator(sample), rsi_expected)
         pd.testing.assert_series_equal(self.VolatilityIndicator(sample, 3), vol_expected)
+        pd.testing.assert_series_equal(self.MACDIndicator(sample, 12, 26, 9), macd_expected)
+        pd.testing.assert_series_equal(self.BollingerBandsIndicator(sample, 3), bb_expected)
+        pd.testing.assert_series_equal(self.ADIIndicator(sample, 3), adi_expected)
         return True

--- a/Parameters.yaml
+++ b/Parameters.yaml
@@ -27,6 +27,12 @@ IndicatorParameters:
   SMAWindow: 5
   EMAWindow: 5
   VolatilityWindow: 5
+  MACDShort: 12
+  MACDLong: 26
+  MACDSignal: 9
+  BBWindow: 20
+  BBStd: 2
+  ADIWindow: 14
 MomentumLookbacks:
   - 5
   - 10
@@ -46,6 +52,9 @@ IndicatorWeights:
   EMA: 1.0
   RSI: 1.0
   Volatility: 1.0
+  MACD: 1.0
+  BB: 1.0
+  ADI: 1.0
 MomentumWeight: 1.0
 AllocationMethod: volatility
 CsvPath: portfolio.csv

--- a/main.py
+++ b/main.py
@@ -36,7 +36,31 @@ def main() -> None:
             vol = engine.VolatilityIndicator(
                 close, config["IndicatorParameters"]["VolatilityWindow"]
             ).dropna().iloc[-1]
-            rows.append({"Ticker": ticker, "SMA": sma, "EMA": ema, "RSI": rsi, "Volatility": vol})
+            macd = engine.MACDIndicator(
+                close,
+                config["IndicatorParameters"]["MACDShort"],
+                config["IndicatorParameters"]["MACDLong"],
+                config["IndicatorParameters"]["MACDSignal"],
+            ).dropna().iloc[-1]
+            bb = engine.BollingerBandsIndicator(
+                close,
+                config["IndicatorParameters"]["BBWindow"],
+                config["IndicatorParameters"]["BBStd"],
+            ).dropna().iloc[-1]
+            adi = engine.ADIIndicator(
+                close,
+                config["IndicatorParameters"]["ADIWindow"],
+            ).dropna().iloc[-1]
+            rows.append({
+                "Ticker": ticker,
+                "SMA": sma,
+                "EMA": ema,
+                "RSI": rsi,
+                "Volatility": vol,
+                "MACD": macd,
+                "BB": bb,
+                "ADI": adi,
+            })
 
         df = pd.DataFrame(rows).set_index("Ticker")
         df_clean = normalizer.MissingValueHandler(df, method="ffill")


### PR DESCRIPTION
## Summary
- extend `IndicatorEngine` with MACD, Bollinger Bands, and ADI implementations
- update sample indicator tests and add unit tests for new indicators
- store new indicator parameters and weights in YAML config
- compute additional indicators in `main.py`