### PR TITLE
Update buy-and-hold comparison

### DIFF
--- a/BacktestingEngine.py
+++ b/BacktestingEngine.py
@@ -139,14 +139,20 @@ class BacktestingEngine:
 
         return cash / self.initial_cash - 1
 
-    def BuyAndHoldReturn(self, tickers: List[str]) -> float:
-        """Compute buy-and-hold return for equally weighted tickers."""
-        LOGGER.info("Calculating buy-and-hold return for tickers: %s", tickers)
-        if not tickers:
+    def BuyAndHoldReturn(self, Tickers) -> float:
+        """Compute buy-and-hold return for a given set of tickers."""
+        LOGGER.info("Calculating buy-and-hold return for tickers: %s", Tickers)
+        if Tickers is None or len(Tickers) == 0:
             raise ValueError("No tickers provided")
-        weight = 1.0 / len(tickers)
-        allocations = pd.Series(weight, index=tickers)
-        return self.PortfolioBacktest(allocations)
+
+        if isinstance(Tickers, pd.Series):
+            SelectedTickers = list(Tickers.index)
+        else:
+            SelectedTickers = list(Tickers)
+
+        Weight = 1.0 / len(SelectedTickers)
+        Allocations = pd.Series(Weight, index=SelectedTickers)
+        return self.PortfolioBacktest(Allocations)
 
     def IntervalBacktest(self, tickers: List[str], months: int) -> float:
         """Backtest with periodic rebalancing using a month interval."""

--- a/UnitTests/test_backtesting_engine.py
+++ b/UnitTests/test_backtesting_engine.py
@@ -41,6 +41,13 @@ class TestBacktestingEngine(unittest.TestCase):
         self.assertGreater(result, 0)
 
     @patch.object(MarketDataFetcher, "MarketDataAdapter")
+    def test_buy_and_hold_with_allocations(self, mock_adapter):
+        mock_adapter.side_effect = self.fake_adapter
+        alloc = self.engine.AllocationFromHistory(["AAA", "BBB", "CCC"])
+        result = self.engine.BuyAndHoldReturn(alloc.index)
+        self.assertGreater(result, 0)
+
+    @patch.object(MarketDataFetcher, "MarketDataAdapter")
     def test_interval_backtest(self, mock_adapter):
         mock_adapter.side_effect = self.fake_adapter
         result = self.engine.IntervalBacktest(["AAA", "BBB", "CCC"], 1)

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ def main() -> None:
         hist_alloc = backtester.AllocationFromHistory(tickers)
         interval = config.get("RebalanceIntervalMonths", 0)
         backtest_return = backtester.PortfolioBacktest(hist_alloc, interval)
-        baseline_return = backtester.BuyAndHoldReturn(tickers)
+        baseline_return = backtester.BuyAndHoldReturn(hist_alloc.index)
         if interval:
             message = f"Interval Backtest return: {backtest_return:.2%}"
         else:


### PR DESCRIPTION
## Summary
- allow `BuyAndHoldReturn` to accept any ticker collection
- update main to compare buy-and-hold using same tickers as backtest
- add unit test for new argument type