### PR TITLE
Implement caching for YFinanceDownloader

### DIFF
--- a/DataDownloader.py
+++ b/DataDownloader.py
@@ -1,14 +1,50 @@
+import os
+import json
 import yfinance as yf
 import pandas as pd
 
 class YFinanceDownloader:
-    def __init__(self, Ticker, StartDate, EndDate, Interval):
+    def __init__(self, Ticker, StartDate, EndDate, Interval, CacheDir="Cache"):
         self.Ticker = Ticker
         self.StartDate = pd.to_datetime(StartDate)
         self.EndDate = pd.to_datetime(EndDate)
         self.Interval = Interval
+        self.CacheDir = CacheDir
+        os.makedirs(self.CacheDir, exist_ok=True)
+
+    def _GetCachePaths(self):
+        CsvFilePath = os.path.join(self.CacheDir, f"{self.Ticker}.csv")
+        MetaFilePath = os.path.join(self.CacheDir, f"{self.Ticker}_meta.json")
+        return CsvFilePath, MetaFilePath
+
+    def _LoadFromCache(self, CsvFilePath, MetaFilePath):
+        if os.path.exists(CsvFilePath) and os.path.exists(MetaFilePath):
+            with open(MetaFilePath, "r") as File:
+                Meta = json.load(File)
+            if (
+                Meta.get("StartDate") == self.StartDate.strftime("%Y-%m-%d")
+                and Meta.get("EndDate") == self.EndDate.strftime("%Y-%m-%d")
+                and Meta.get("Interval") == self.Interval
+            ):
+                return pd.read_csv(CsvFilePath, index_col=0, parse_dates=True)
+        return None
+
+    def _SaveToCache(self, DataFrame, CsvFilePath, MetaFilePath):
+        DataFrame.to_csv(CsvFilePath)
+        Meta = {
+            "StartDate": self.StartDate.strftime("%Y-%m-%d"),
+            "EndDate": self.EndDate.strftime("%Y-%m-%d"),
+            "Interval": self.Interval,
+        }
+        with open(MetaFilePath, "w") as File:
+            json.dump(Meta, File)
 
     def DownloadData(self):
+        CsvFilePath, MetaFilePath = self._GetCachePaths()
+        CachedDf = self._LoadFromCache(CsvFilePath, MetaFilePath)
+        if CachedDf is not None:
+            return CachedDf
+
         # For hourly data, yfinance limits the period that can be downloaded.
         # We define common hourly interval labels.
         HourlyIntervals = ['60m', '1h', 'hourly']
@@ -39,6 +75,7 @@ class YFinanceDownloader:
 
                 if DataFrames:
                     FinalDf = pd.concat(DataFrames)
+                    self._SaveToCache(FinalDf, CsvFilePath, MetaFilePath)
                     return FinalDf
                 
         # For non-hourly data or periods within the 2-week limit, download directly.
@@ -53,6 +90,7 @@ class YFinanceDownloader:
         if isinstance(FinalDf.columns, pd.MultiIndex):
             FinalDf.columns = FinalDf.columns.droplevel(1)
 
-        FinalDf.columns.name = None 
+        FinalDf.columns.name = None
+        self._SaveToCache(FinalDf, CsvFilePath, MetaFilePath)
 
         return FinalDf

--- a/UnitTests/test_yfinance_downloader.py
+++ b/UnitTests/test_yfinance_downloader.py
@@ -1,0 +1,36 @@
+import os
+import json
+import pandas as pd
+from unittest.mock import patch
+from DataDownloader import YFinanceDownloader
+
+
+def test_cache_usage(tmp_path):
+    CachePath = tmp_path / "Cache"
+    CachePath.mkdir()
+    TestDf = pd.DataFrame({"Close": [1, 2, 3]}, index=pd.date_range("2022-01-01", periods=3))
+
+    with patch("DataDownloader.yf.download", return_value=TestDf) as MockDownload:
+        Downloader = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-03", "1d", CacheDir=str(CachePath))
+        Data1 = Downloader.DownloadData()
+        assert MockDownload.call_count == 1
+        CsvFile = CachePath / "AAPL.csv"
+        MetaFile = CachePath / "AAPL_meta.json"
+        assert CsvFile.exists() and MetaFile.exists()
+        assert Data1.equals(TestDf)
+
+    with patch("DataDownloader.yf.download", return_value=TestDf) as MockDownload:
+        Downloader = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-03", "1d", CacheDir=str(CachePath))
+        Data2 = Downloader.DownloadData()
+        assert MockDownload.call_count == 0
+        assert Data2.equals(TestDf)
+
+    NewDf = pd.DataFrame({"Close": [4, 5, 6]}, index=pd.date_range("2022-01-01", periods=3))
+    with patch("DataDownloader.yf.download", return_value=NewDf) as MockDownload:
+        Downloader = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-03", "1h", CacheDir=str(CachePath))
+        Data3 = Downloader.DownloadData()
+        assert MockDownload.call_count == 1
+        with open(CachePath / "AAPL_meta.json") as MetaFile:
+            Meta = json.load(MetaFile)
+        assert Meta["Interval"] == "1h"
+        assert Data3.equals(NewDf)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+from DataDownloader import YFinanceDownloader
+
+if __name__ == "__main__":
+    Downloader = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-10", "1d")
+    Data = Downloader.DownloadData()
+    print(Data.head())


### PR DESCRIPTION
## Summary
- add local cache support to `YFinanceDownloader`
- provide a simple `main.py` example
- test caching logic in `UnitTests/test_yfinance_downloader.py`