### PR TITLE
Enable multi-ticker downloads

### DIFF
--- a/ConfigManager.yaml
+++ b/ConfigManager.yaml
@@ -3,3 +3,6 @@ StartDate: "2020-01-01"
 EndDate: "2024-12-31"
 Interval: "1d"
 CacheDir: "Cache"
+Tickers:
+  - "AAPL"
+  - "MSFT"

--- a/DataDownloader.py
+++ b/DataDownloader.py
@@ -45,7 +45,7 @@ class YFinanceDownloader:
             json.dump(Meta, File)
         logging.getLogger(__name__).info("Saved data for %s to cache", self.Ticker)
 
-    def DownloadData(self):
+    def _DownloadSingleTicker(self):
         CsvFilePath, MetaFilePath = self._GetCachePaths()
         CachedDf = self._LoadFromCache(CsvFilePath, MetaFilePath)
         if CachedDf is not None:
@@ -103,3 +103,25 @@ class YFinanceDownloader:
         logging.getLogger(__name__).info("Downloaded data for %s", self.Ticker)
 
         return FinalDf
+
+    def DownloadData(self, Tickers=None):
+        if Tickers is None:
+            DataFrame = self._DownloadSingleTicker()
+            DataFrame["Ticker"] = self.Ticker
+            return DataFrame
+
+        if isinstance(Tickers, str):
+            TickerList = [Tickers]
+        else:
+            TickerList = list(Tickers)
+
+        CombinedFrames = []
+        OriginalTicker = self.Ticker
+        for SingleTicker in TickerList:
+            self.Ticker = SingleTicker
+            TempDf = self._DownloadSingleTicker()
+            TempDf["Ticker"] = SingleTicker
+            CombinedFrames.append(TempDf)
+        self.Ticker = OriginalTicker
+
+        return pd.concat(CombinedFrames) if CombinedFrames else pd.DataFrame()

--- a/UnitTests/test_yfinance_downloader.py
+++ b/UnitTests/test_yfinance_downloader.py
@@ -17,13 +17,17 @@ def test_cache_usage(tmp_path):
         CsvFile = CachePath / "AAPL.csv"
         MetaFile = CachePath / "AAPL_meta.json"
         assert CsvFile.exists() and MetaFile.exists()
-        assert Data1.equals(TestDf)
+        Expected = TestDf.copy()
+        Expected["Ticker"] = "AAPL"
+        assert Data1.equals(Expected)
 
     with patch("DataDownloader.yf.download", return_value=TestDf) as MockDownload:
         Downloader = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-03", "1d", CacheDir=str(CachePath))
         Data2 = Downloader.DownloadData()
         assert MockDownload.call_count == 0
-        assert Data2.equals(TestDf)
+        Expected = TestDf.copy()
+        Expected["Ticker"] = "AAPL"
+        assert Data2.equals(Expected)
 
     NewDf = pd.DataFrame({"Close": [4, 5, 6]}, index=pd.date_range("2022-01-01", periods=3))
     with patch("DataDownloader.yf.download", return_value=NewDf) as MockDownload:
@@ -33,4 +37,25 @@ def test_cache_usage(tmp_path):
         with open(CachePath / "AAPL_meta.json") as MetaFile:
             Meta = json.load(MetaFile)
         assert Meta["Interval"] == "1h"
-        assert Data3.equals(NewDf)
+        Expected = NewDf.copy()
+        Expected["Ticker"] = "AAPL"
+        assert Data3.equals(Expected)
+
+
+def test_multi_ticker_download(tmp_path):
+    CachePath = tmp_path / "Cache"
+    CachePath.mkdir()
+
+    DfA = pd.DataFrame({"Close": [1]}, index=pd.date_range("2022-01-01", periods=1))
+    DfB = pd.DataFrame({"Close": [2]}, index=pd.date_range("2022-01-01", periods=1))
+
+    with patch("DataDownloader.yf.download", side_effect=[DfA, DfB]) as MockDownload:
+        Downloader = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-01", "1d", CacheDir=str(CachePath))
+        Result = Downloader.DownloadData(["AAPL", "MSFT"])
+        assert MockDownload.call_count == 2
+        ExpectedA = DfA.copy()
+        ExpectedA["Ticker"] = "AAPL"
+        ExpectedB = DfB.copy()
+        ExpectedB["Ticker"] = "MSFT"
+        Expected = pd.concat([ExpectedA, ExpectedB])
+        assert Result.equals(Expected)

--- a/main.py
+++ b/main.py
@@ -13,4 +13,6 @@ if __name__ == "__main__":
         Manager.GetParameter("Interval"),
         CacheDir=Manager.GetParameter("CacheDir")
     )
-    Data = Downloader.DownloadData()
+    Tickers = Manager.GetParameter("Tickers")
+    Data = Downloader.DownloadData(Tickers)
+    logging.getLogger(__name__).info("Data downloaded: %d rows", len(Data))


### PR DESCRIPTION
## Summary
- update downloader to handle a list of tickers and add a 'Ticker' column
- extend yfinance unit tests for new behavior
- support optional ticker list in configuration and main entrypoint