### PR TITLE
Add performance metric class and tests

### DIFF
--- a/PerformanceMetric.py
+++ b/PerformanceMetric.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import numpy as np
+
+class PerformanceMetric:
+    def __init__(self, DataFrame):
+        self.DataFrame = DataFrame.copy()
+
+    def _GroupByTicker(self):
+        if 'Ticker' not in self.DataFrame.columns:
+            raise ValueError('Ticker column missing from DataFrame')
+        return self.DataFrame.groupby('Ticker')
+
+    @staticmethod
+    def _CalculateDailyReturns(Series):
+        Returns = Series.pct_change().dropna()
+        return Returns
+
+    def CalculateCompoundAnnualGrowthRate(self):
+        Results = {}
+        for Ticker, Group in self._GroupByTicker():
+            FirstPrice = Group['Close'].iloc[0]
+            LastPrice = Group['Close'].iloc[-1]
+            Days = (Group.index[-1] - Group.index[0]).days or 1
+            Cagr = (LastPrice / FirstPrice) ** (365 / Days) - 1
+            Results[Ticker] = Cagr
+        return pd.Series(Results)
+
+    def CalculateVolatility(self):
+        Results = {}
+        for Ticker, Group in self._GroupByTicker():
+            Returns = self._CalculateDailyReturns(Group['Close'])
+            Vol = Returns.std() * np.sqrt(252)
+            Results[Ticker] = Vol
+        return pd.Series(Results)
+
+    def CalculateMaxDrawdown(self):
+        Results = {}
+        for Ticker, Group in self._GroupByTicker():
+            Cumulative = Group['Close'] / Group['Close'].iloc[0]
+            RunningMax = Cumulative.cummax()
+            Drawdown = (Cumulative - RunningMax) / RunningMax
+            Results[Ticker] = Drawdown.min()
+        return pd.Series(Results)
+
+    def CalculateSharpeRatio(self, RiskFreeRate=0.0):
+        Results = {}
+        for Ticker, Group in self._GroupByTicker():
+            Returns = self._CalculateDailyReturns(Group['Close'])
+            Excess = Returns - RiskFreeRate / 252
+            Sharpe = Excess.mean() / Returns.std() * np.sqrt(252)
+            Results[Ticker] = Sharpe
+        return pd.Series(Results)
+
+    def GenerateMetrics(self):
+        Cagr = self.CalculateCompoundAnnualGrowthRate()
+        Vol = self.CalculateVolatility()
+        Mdd = self.CalculateMaxDrawdown()
+        Sharpe = self.CalculateSharpeRatio()
+        MetricsDf = pd.concat([
+            Cagr.rename('CAGR'),
+            Vol.rename('Volatility'),
+            Mdd.rename('MaxDrawdown'),
+            Sharpe.rename('SharpeRatio')
+        ], axis=1)
+        MetricsDf.index.name = 'Ticker'
+        return MetricsDf

--- a/UnitTests/test_performance_metric.py
+++ b/UnitTests/test_performance_metric.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import numpy as np
+from PerformanceMetric import PerformanceMetric
+
+
+def test_generate_metrics():
+    Dates = pd.date_range('2022-01-01', periods=3)
+    Data = pd.DataFrame({
+        'Close': [100, 105, 102.9],
+        'Ticker': ['AAPL'] * 3
+    }, index=Dates)
+
+    Metrics = PerformanceMetric(Data).GenerateMetrics()
+
+    Days = (Dates[-1] - Dates[0]).days
+    Cagr = (102.9 / 100) ** (365 / Days) - 1
+    Returns = pd.Series([0.05, -0.02])
+    Vol = Returns.std() * np.sqrt(252)
+    Cumulative = Data['Close'] / Data['Close'].iloc[0]
+    RunningMax = Cumulative.cummax()
+    Drawdown = (Cumulative - RunningMax) / RunningMax
+    MaxDd = Drawdown.min()
+    Excess = Returns - 0 / 252
+    Sharpe = Excess.mean() / Returns.std() * np.sqrt(252)
+
+    Expected = pd.DataFrame({
+        'CAGR': [Cagr],
+        'Volatility': [Vol],
+        'MaxDrawdown': [MaxDd],
+        'SharpeRatio': [Sharpe]
+    }, index=pd.Index(['AAPL'], name='Ticker'))
+
+    pd.testing.assert_frame_equal(Metrics, Expected)
+

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from DataDownloader import YFinanceDownloader
 from ConfigManager import ConfigManager
 from LoggingManager import LoggingManager
+from PerformanceMetric import PerformanceMetric
 import logging
 
 if __name__ == "__main__":
@@ -16,3 +17,6 @@ if __name__ == "__main__":
     Tickers = Manager.GetParameter("Tickers")
     Data = Downloader.DownloadData(Tickers)
     logging.getLogger(__name__).info("Data downloaded: %d rows", len(Data))
+
+    Metrics = PerformanceMetric(Data).GenerateMetrics()
+    logging.getLogger(__name__).info("\n%s", Metrics)


### PR DESCRIPTION
## Summary
- implement `PerformanceMetric` class with CAGR, volatility, max drawdown and Sharpe ratio calculations
- expose metrics in `main.py`
- add unit test for performance metrics