### PR TITLE
Add exponential-decay asset allocation

### DIFF
--- a/AssetAllocation.py
+++ b/AssetAllocation.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import numpy as np
+
+class AssetAllocation:
+    def __init__(self, RankingDataFrame, Config):
+        self.RankingDataFrame = RankingDataFrame.copy()
+        self.Config = Config
+        self.TopNPercent = float(self.Config.GetParameter("TopN", 10))
+        self.Alpha = float(self.Config.GetParameter("Alpha", 1))
+
+    def GenerateAllocations(self):
+        if "CompositeRank" not in self.RankingDataFrame.columns:
+            raise ValueError("CompositeRank not found in ranking data")
+
+        SortedDf = self.RankingDataFrame.sort_values("CompositeRank")
+        Count = len(SortedDf)
+        TopCount = max(int(np.ceil(Count * self.TopNPercent / 100)), 1)
+        TopDf = SortedDf.head(TopCount).copy()
+
+        Ranks = np.arange(TopCount)
+        Weights = np.exp(-self.Alpha * Ranks)
+        Weights /= Weights.sum()
+        TopDf["Allocation"] = Weights
+
+        return TopDf[["Allocation"]]

--- a/ConfigManager.yaml
+++ b/ConfigManager.yaml
@@ -32,3 +32,5 @@ CompositeMetrics:
   - "MaxDrawdown"
   - "SharpeRatio"
 
+TopN: 10
+Alpha: 0.5

--- a/UnitTests/test_asset_allocation.py
+++ b/UnitTests/test_asset_allocation.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import yaml
+import pandas as pd
+import numpy as np
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AssetAllocation import AssetAllocation
+from ConfigManager import ConfigManager
+
+
+def test_generate_allocations(tmp_path):
+    Ranking = pd.DataFrame({'CompositeRank': [1, 2, 3]}, index=['A', 'B', 'C'])
+    ConfigFile = tmp_path / 'config.yaml'
+    with open(ConfigFile, 'w') as File:
+        yaml.dump({'TopN': 50, 'Alpha': 1}, File)
+    Config = ConfigManager(ConfigPath=str(ConfigFile))
+    Allocation = AssetAllocation(Ranking, Config).GenerateAllocations()
+    Weights = np.exp(-1 * np.arange(2))
+    Weights /= Weights.sum()
+    Expected = pd.DataFrame({'Allocation': Weights}, index=['A', 'B'])
+    pd.testing.assert_frame_equal(Allocation, Expected)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from ConfigManager import ConfigManager
 from LoggingManager import LoggingManager
 from PerformanceMetric import PerformanceMetric
 from PerformanceRanking import PerformanceRanking
+from AssetAllocation import AssetAllocation
 import logging
 
 if __name__ == "__main__":
@@ -28,3 +29,6 @@ if __name__ == "__main__":
     )
     Ranking = PerformanceRanking(Metrics).GenerateCompositeRanking(CompositeMetrics)
     logging.getLogger(__name__).info("\n%s", Ranking)
+
+    Allocation = AssetAllocation(Ranking, Manager).GenerateAllocations()
+    logging.getLogger(__name__).info("\n%s", Allocation)


### PR DESCRIPTION
## Summary
- implement `AssetAllocation` class for allocating capital based on ranking
- add `TopN` and `Alpha` parameters in configuration
- integrate allocation step in `main.py`
- add unit test for new class

## Testing
- `pytest -q`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_684ee212697c8320b9728690ef476f0d