### PR TITLE
Add BacktestEngine for portfolio backtesting

### DIFF
--- a/BacktestEngine.py
+++ b/BacktestEngine.py
@@ -1,0 +1,55 @@
+import pandas as pd
+from backtesting import Backtest, Strategy
+from DataDownloader import YFinanceDownloader
+
+class BuyAndHoldStrategy(Strategy):
+    def init(self):
+        self.buy()
+
+    def next(self):
+        pass
+
+class BacktestEngine:
+    def __init__(self, AllocationDataFrame, StartDate="2024-01-01", EndDate="2024-12-31", Interval="1d", CacheDir="Cache"):
+        self.AllocationDataFrame = AllocationDataFrame.copy()
+        self.StartDate = StartDate
+        self.EndDate = EndDate
+        self.Interval = Interval
+        self.CacheDir = CacheDir
+
+    def _DownloadPrices(self, Tickers):
+        Downloader = YFinanceDownloader(Tickers[0], self.StartDate, self.EndDate, self.Interval, CacheDir=self.CacheDir)
+        Data = Downloader.DownloadData(Tickers)
+        return Data
+
+    @staticmethod
+    def _BuildPortfolioSeries(Data, Weights):
+        Data = Data.reset_index().rename(columns={Data.index.name or 'index': 'Date'})
+        PriceDf = Data.pivot(index='Date', columns='Ticker', values='Close')
+        PriceDf.sort_index(inplace=True)
+        PriceDf.fillna(method='ffill', inplace=True)
+        PriceDf.dropna(inplace=True)
+        Normalized = PriceDf / PriceDf.iloc[0]
+        Portfolio = (Normalized * Weights).sum(axis=1)
+        return Portfolio
+
+    @staticmethod
+    def _RunSingleBacktest(Series):
+        DataFrame = pd.DataFrame({'Open': Series, 'High': Series, 'Low': Series, 'Close': Series, 'Volume': 0})
+        Bt = Backtest(DataFrame, BuyAndHoldStrategy, cash=10000, commission=0, exclusive_orders=True)
+        Stats = Bt.run()
+        return Stats
+
+    def RunBacktest(self):
+        Tickers = list(self.AllocationDataFrame.index)
+        Prices = self._DownloadPrices(Tickers)
+
+        WeightSeries = self.AllocationDataFrame['Allocation']
+        PortfolioWeighted = self._BuildPortfolioSeries(Prices, WeightSeries)
+        WeightedStats = self._RunSingleBacktest(PortfolioWeighted)
+
+        EqualWeights = pd.Series(1.0 / len(Tickers), index=Tickers)
+        PortfolioEqual = self._BuildPortfolioSeries(Prices, EqualWeights)
+        BaselineStats = self._RunSingleBacktest(PortfolioEqual)
+
+        return WeightedStats, BaselineStats

--- a/UnitTests/test_backtest_engine.py
+++ b/UnitTests/test_backtest_engine.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pandas as pd
+from unittest.mock import patch
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from BacktestEngine import BacktestEngine
+
+
+def _mock_download(*args, **kwargs):
+    dates = pd.date_range('2024-01-01', periods=3)
+    df_a = pd.DataFrame({
+        'Open': [100, 110, 120],
+        'High': [100, 110, 120],
+        'Low': [100, 110, 120],
+        'Close': [100, 110, 120],
+        'Volume': [1, 1, 1]
+    }, index=dates)
+    df_a['Ticker'] = 'AAA'
+
+    df_b = pd.DataFrame({
+        'Open': [50, 55, 60],
+        'High': [50, 55, 60],
+        'Low': [50, 55, 60],
+        'Close': [50, 55, 60],
+        'Volume': [1, 1, 1]
+    }, index=dates)
+    df_b['Ticker'] = 'BBB'
+    return pd.concat([df_a, df_b])
+
+
+def test_run_backtest(monkeypatch):
+    alloc = pd.DataFrame({'Allocation': [0.6, 0.4]}, index=['AAA', 'BBB'])
+    with patch('BacktestEngine.YFinanceDownloader.DownloadData', side_effect=_mock_download):
+        engine = BacktestEngine(alloc)
+        stats_weighted, stats_equal = engine.RunBacktest()
+        assert 'Return [%]' in stats_weighted
+        assert 'Return [%]' in stats_equal

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from LoggingManager import LoggingManager
 from PerformanceMetric import PerformanceMetric
 from PerformanceRanking import PerformanceRanking
 from AssetAllocation import AssetAllocation
+from BacktestEngine import BacktestEngine
 import logging
 
 if __name__ == "__main__":
@@ -32,3 +33,8 @@ if __name__ == "__main__":
 
     Allocation = AssetAllocation(Ranking, Manager).GenerateAllocations()
     logging.getLogger(__name__).info("\n%s", Allocation)
+
+    Engine = BacktestEngine(Allocation)
+    WeightedStats, EqualStats = Engine.RunBacktest()
+    logging.getLogger(__name__).info("Weighted Allocation Stats:\n%s", WeightedStats)
+    logging.getLogger(__name__).info("Equal Allocation Stats:\n%s", EqualStats)


### PR DESCRIPTION
## Summary
- add new BacktestEngine for evaluating weighted and equal portfolios
- add unit test for BacktestEngine
- update main pipeline to run backtest engine