### PR TITLE
Enhance caching for YFinance downloads

### DIFF
--- a/DataDownloader.py
+++ b/DataDownloader.py
@@ -16,10 +16,20 @@ class YFinanceDownloader:
             "Initialized YFinanceDownloader for %s", self.Ticker
         )
 
+    def _GetCacheFileBase(self):
+        StartStr = self.StartDate.strftime("%Y%m%d")
+        EndStr = self.EndDate.strftime("%Y%m%d")
+        FileBase = f"{self.Ticker}_{StartStr}_{EndStr}_{self.Interval}"
+        return FileBase
+
     def _GetCachePaths(self):
-        CsvFilePath = os.path.join(self.CacheDir, f"{self.Ticker}.csv")
-        MetaFilePath = os.path.join(self.CacheDir, f"{self.Ticker}_meta.json")
+        FileBase = self._GetCacheFileBase()
+        CsvFilePath = os.path.join(self.CacheDir, f"{FileBase}.csv")
+        MetaFilePath = os.path.join(self.CacheDir, f"{FileBase}_meta.json")
         return CsvFilePath, MetaFilePath
+
+    def GetCachePaths(self):
+        return self._GetCachePaths()
 
     def _LoadFromCache(self, CsvFilePath, MetaFilePath):
         if os.path.exists(CsvFilePath) and os.path.exists(MetaFilePath):

--- a/UnitTests/test_yfinance_downloader.py
+++ b/UnitTests/test_yfinance_downloader.py
@@ -16,8 +16,9 @@ def test_cache_usage(tmp_path):
         Downloader = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-03", "1d", CacheDir=str(CachePath))
         Data1 = Downloader.DownloadData()
         assert MockDownload.call_count == 1
-        CsvFile = CachePath / "AAPL.csv"
-        MetaFile = CachePath / "AAPL_meta.json"
+        FileBase = "AAPL_20220101_20220103_1d"
+        CsvFile = CachePath / f"{FileBase}.csv"
+        MetaFile = CachePath / f"{FileBase}_meta.json"
         assert CsvFile.exists() and MetaFile.exists()
         Expected = TestDf.copy()
         Expected["Ticker"] = "AAPL"
@@ -36,7 +37,8 @@ def test_cache_usage(tmp_path):
         Downloader = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-03", "1h", CacheDir=str(CachePath))
         Data3 = Downloader.DownloadData()
         assert MockDownload.call_count == 1
-        with open(CachePath / "AAPL_meta.json") as MetaFile:
+        FileBaseNew = "AAPL_20220101_20220103_1h"
+        with open(CachePath / f"{FileBaseNew}_meta.json") as MetaFile:
             Meta = json.load(MetaFile)
         assert Meta["Interval"] == "1h"
         Expected = NewDf.copy()
@@ -61,3 +63,27 @@ def test_multi_ticker_download(tmp_path):
         ExpectedB["Ticker"] = "MSFT"
         Expected = pd.concat([ExpectedA, ExpectedB])
         assert Result.equals(Expected)
+
+
+def test_separate_date_range_cache(tmp_path):
+    CachePath = tmp_path / "Cache"
+    CachePath.mkdir()
+
+    TrainDf = pd.DataFrame({"Close": [1]}, index=pd.date_range("2022-01-01", periods=1))
+    ValidDf = pd.DataFrame({"Close": [2]}, index=pd.date_range("2023-01-01", periods=1))
+
+    with patch("DataDownloader.yf.download", side_effect=[TrainDf, ValidDf]) as MockDownload:
+        DownloaderTrain = YFinanceDownloader("AAPL", "2022-01-01", "2022-01-02", "1d", CacheDir=str(CachePath))
+        DataTrain = DownloaderTrain.DownloadData()
+        DownloaderValid = YFinanceDownloader("AAPL", "2023-01-01", "2023-01-02", "1d", CacheDir=str(CachePath))
+        DataValid = DownloaderValid.DownloadData()
+
+        assert MockDownload.call_count == 2
+
+        TrainFile = CachePath / "AAPL_20220101_20220102_1d.csv"
+        ValidFile = CachePath / "AAPL_20230101_20230102_1d.csv"
+
+        assert TrainFile.exists() and ValidFile.exists()
+
+        assert DataTrain.iloc[0]['Close'] == 1
+        assert DataValid.iloc[0]['Close'] == 2

--- a/main.py
+++ b/main.py
@@ -17,6 +17,8 @@ if __name__ == "__main__":
         Manager.GetParameter("Interval"),
         CacheDir=Manager.GetParameter("CacheDir")
     )
+    CsvPath, _ = Downloader.GetCachePaths()
+    logging.getLogger(__name__).info("Using cache file %s", CsvPath)
     Tickers = Manager.GetParameter("Tickers")
     Data = Downloader.DownloadData(Tickers)
     logging.getLogger(__name__).info("Data downloaded: %d rows", len(Data))


### PR DESCRIPTION
## Summary
- make YFinance cache filenames include date range and interval
- update downloader unit tests and add new test for unique cache per date range
- log cache file path in main