### PR TITLE
Fix BacktestEngine ffill warning

### DIFF
--- a/BacktestEngine.py
+++ b/BacktestEngine.py
@@ -27,7 +27,7 @@ class BacktestEngine:
         Data = Data.reset_index().rename(columns={Data.index.name or 'index': 'Date'})
         PriceDf = Data.pivot(index='Date', columns='Ticker', values='Close')
         PriceDf.sort_index(inplace=True)
-        PriceDf.fillna(method='ffill', inplace=True)
+        PriceDf.ffill(inplace=True)
         PriceDf.dropna(inplace=True)
         Normalized = PriceDf / PriceDf.iloc[0]
         Portfolio = (Normalized * Weights).sum(axis=1)

--- a/UnitTests/test_backtest_engine.py
+++ b/UnitTests/test_backtest_engine.py
@@ -35,3 +35,23 @@ def test_run_backtest(monkeypatch):
         stats_weighted, stats_equal = engine.RunBacktest()
         assert 'Return [%]' in stats_weighted
         assert 'Return [%]' in stats_equal
+
+
+def test_build_portfolio_series_ffill():
+    dates = pd.date_range('2024-01-01', periods=3)
+    df_a = pd.DataFrame({'Close': [100, 110, 120]}, index=dates)
+    df_a['Ticker'] = 'AAA'
+    df_b = pd.DataFrame({'Close': [50, None, 60]}, index=dates)
+    df_b['Ticker'] = 'BBB'
+    data = pd.concat([df_a, df_b])
+    weights = pd.Series({'AAA': 0.6, 'BBB': 0.4})
+    result = BacktestEngine._BuildPortfolioSeries(data, weights)
+
+    price_df = pd.DataFrame({'AAA': [100, 110, 120], 'BBB': [50, None, 60]}, index=dates)
+    price_df.ffill(inplace=True)
+    normalized = price_df / price_df.iloc[0]
+    expected = (normalized * weights).sum(axis=1)
+    expected.index.name = 'Date'
+    expected.index.freq = None
+
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- replace deprecated `fillna(method='ffill')` with `ffill()`
- add test ensuring portfolio series forward fills gaps