### PR TITLE
Add Sortino ratio metric

### DIFF
--- a/ConfigManager.yaml
+++ b/ConfigManager.yaml
@@ -31,6 +31,7 @@ CompositeMetrics:
   - "Volatility"
   - "MaxDrawdown"
   - "SharpeRatio"
+  - "SortinoRatio"
 
 TopN: 50
 Alpha: 0.4

--- a/PerformanceMetric.py
+++ b/PerformanceMetric.py
@@ -51,16 +51,28 @@ class PerformanceMetric:
             Results[Ticker] = Sharpe
         return pd.Series(Results)
 
+    def CalculateSortinoRatio(self, RiskFreeRate=0.0):
+        Results = {}
+        for Ticker, Group in self._GroupByTicker():
+            Returns = self._CalculateDailyReturns(Group['Close'])
+            Excess = Returns - RiskFreeRate / 252
+            DownsideStd = Returns[Returns < 0].std()
+            Sortino = Excess.mean() / DownsideStd * np.sqrt(252)
+            Results[Ticker] = Sortino
+        return pd.Series(Results)
+
     def GenerateMetrics(self):
         Cagr = self.CalculateCompoundAnnualGrowthRate()
         Vol = self.CalculateVolatility()
         Mdd = self.CalculateMaxDrawdown()
         Sharpe = self.CalculateSharpeRatio()
+        Sortino = self.CalculateSortinoRatio()
         MetricsDf = pd.concat([
             Cagr.rename('CAGR'),
             Vol.rename('Volatility'),
             Mdd.rename('MaxDrawdown'),
-            Sharpe.rename('SharpeRatio')
+            Sharpe.rename('SharpeRatio'),
+            Sortino.rename('SortinoRatio')
         ], axis=1)
         MetricsDf.index.name = 'Ticker'
         return MetricsDf

--- a/PerformanceRanking.py
+++ b/PerformanceRanking.py
@@ -9,7 +9,8 @@ class PerformanceRanking:
             "CAGR": False,
             "Volatility": True,
             "MaxDrawdown": False,
-            "SharpeRatio": False
+            "SharpeRatio": False,
+            "SortinoRatio": False
         }
 
     def GenerateRanking(self):

--- a/UnitTests/test_performance_metric.py
+++ b/UnitTests/test_performance_metric.py
@@ -25,12 +25,14 @@ def test_generate_metrics():
     MaxDd = Drawdown.min()
     Excess = Returns - 0 / 252
     Sharpe = Excess.mean() / Returns.std() * np.sqrt(252)
+    Sortino = Excess.mean() / Returns[Returns < 0].std() * np.sqrt(252)
 
     Expected = pd.DataFrame({
         'CAGR': [Cagr],
         'Volatility': [Vol],
         'MaxDrawdown': [MaxDd],
-        'SharpeRatio': [Sharpe]
+        'SharpeRatio': [Sharpe],
+        'SortinoRatio': [Sortino]
     }, index=pd.Index(['AAPL'], name='Ticker'))
 
     pd.testing.assert_frame_equal(Metrics, Expected)

--- a/UnitTests/test_performance_ranking.py
+++ b/UnitTests/test_performance_ranking.py
@@ -10,7 +10,8 @@ def test_generate_ranking():
         'CAGR': [0.1, 0.2],
         'Volatility': [0.2, 0.15],
         'MaxDrawdown': [-0.1, -0.2],
-        'SharpeRatio': [1.0, 1.2]
+        'SharpeRatio': [1.0, 1.2],
+        'SortinoRatio': [1.5, 2.0]
     }, index=pd.Index(['AAPL', 'MSFT'], name='Ticker'))
 
     Ranking = PerformanceRanking(Metrics).GenerateRanking()
@@ -19,7 +20,8 @@ def test_generate_ranking():
         'CAGR': [2, 1],
         'Volatility': [2, 1],
         'MaxDrawdown': [1, 2],
-        'SharpeRatio': [2, 1]
+        'SharpeRatio': [2, 1],
+        'SortinoRatio': [2, 1]
     }, index=Metrics.index)
 
     pd.testing.assert_frame_equal(Ranking, Expected)
@@ -30,10 +32,11 @@ def test_generate_composite_ranking():
         'CAGR': [0.1, 0.2],
         'Volatility': [0.2, 0.15],
         'MaxDrawdown': [-0.1, -0.2],
-        'SharpeRatio': [1.0, 1.2]
+        'SharpeRatio': [1.0, 1.2],
+        'SortinoRatio': [1.5, 2.0]
     }, index=pd.Index(['AAPL', 'MSFT'], name='Ticker'))
 
-    CompositeList = ['CAGR', 'Volatility', 'MaxDrawdown', 'SharpeRatio']
+    CompositeList = ['CAGR', 'Volatility', 'MaxDrawdown', 'SharpeRatio', 'SortinoRatio']
     Ranking = PerformanceRanking(Metrics).GenerateCompositeRanking(CompositeList)
 
     Expected = pd.DataFrame({
@@ -41,6 +44,7 @@ def test_generate_composite_ranking():
         'Volatility': [2, 1],
         'MaxDrawdown': [1, 2],
         'SharpeRatio': [2, 1],
+        'SortinoRatio': [2, 1],
         'CompositeRank': [2, 1]
     }, index=Metrics.index)
 

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
 
     CompositeMetrics = Manager.GetParameter(
         "CompositeMetrics",
-        ["CAGR", "Volatility", "MaxDrawdown", "SharpeRatio"],
+        ["CAGR", "Volatility", "MaxDrawdown", "SharpeRatio", "SortinoRatio"],
     )
     Ranking = PerformanceRanking(Metrics).GenerateCompositeRanking(CompositeMetrics)
     logging.getLogger(__name__).info("\n%s", Ranking)


### PR DESCRIPTION
## Summary
- implement `CalculateSortinoRatio` in `PerformanceMetric`
- include Sortino ratio in metric generation
- rank Sortino ratio in `PerformanceRanking`
- update configuration and default composite metrics
- expand unit tests for Sortino ratio calculation and ranking